### PR TITLE
Add Plausible Analytics

### DIFF
--- a/website/themes/minimal/templates/base.html
+++ b/website/themes/minimal/templates/base.html
@@ -40,6 +40,9 @@
         <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
         <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}" />
 
+        <!-- Plausible Analytics -->
+        <script async defer data-domain="iwanttoreadmore.com" src="https://plausible.io/js/plausible.js"></script>
+
         <!-- RSS and Atom feeds -->
         {% if FEED_ALL_ATOM %}
         <link


### PR DESCRIPTION
This PR integrates [Plausible Analytics](https://plausible.io/) to gather client side visitor statistics.