### PR TITLE
Switch to Cooltipz CSS

### DIFF
--- a/website/themes/minimal/static/css/iwrm.css
+++ b/website/themes/minimal/static/css/iwrm.css
@@ -1,0 +1,68 @@
+[title][data-vote] {
+    cursor: pointer;
+    position: relative;
+}
+
+[title][data-vote]:hover::before,
+[title][data-vote]:hover::after {
+    opacity: 1;
+    -webkit-transition-delay: 0s;
+    transition-delay: 0s;
+    -webkit-transform: translate(-50%, 0);
+    transform: translate(-50%, 0);
+}
+
+[title][data-vote]::before,
+[title][data-vote]::after {
+    -webkit-transition: all 120ms ease-out 120ms;
+    transition: all 120ms ease-out 120ms;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    -webkit-transition-delay: 0s;
+    transition-delay: 0s;
+    bottom: calc(100% - (0.3125rem / 2));
+    left: 50%;
+    -webkit-transform: translate(-50%, 6px);
+    transform: translate(-50%, 6px);
+    -webkit-transform-origin: top;
+    transform-origin: top;
+}
+
+[title][data-vote]::before {
+    content: "";
+    z-index: 11;
+    border: 0.3125rem solid transparent;
+    height: 0;
+    width: 0;
+    border-top-color: #1f1f1f;
+    -webkit-filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.3));
+}
+
+[title][data-vote]::after {
+    background-color: #1f1f1f;
+    border-radius: 0.125rem;
+    -webkit-box-shadow: 0 0 0.1875rem rgba(0, 0, 0, 0.3);
+    box-shadow: 0 0 0.1875rem rgba(0, 0, 0, 0.3);
+    color: #fff;
+    content: attr(title);
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    font-size: 0.75rem;
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-style: normal;
+    padding: 0.5em 1em;
+    text-indent: 0;
+    text-shadow: none;
+    white-space: nowrap;
+    z-index: 10;
+    text-align: center;
+    white-space: normal;
+    word-wrap: break-word;
+    margin-bottom: calc(0.3125rem * 2);
+    width: 12.5rem;
+}

--- a/website/themes/minimal/templates/base.html
+++ b/website/themes/minimal/templates/base.html
@@ -43,6 +43,7 @@
             crossorigin="anonymous"
         />
         <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}" />
+        <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/iwrm.css" />
 
         <link
             rel="stylesheet"

--- a/website/themes/minimal/templates/iwrm_macros.j2
+++ b/website/themes/minimal/templates/iwrm_macros.j2
@@ -2,16 +2,12 @@
 <a
     href="#"
     data-vote="{{ user }}/{{ project }}/{{ topic }}" 
-    data-toggle="tooltip" 
-    data-placement="top" 
-    aria-label="vote"
+    aria-label="Click if you want me to write more about this topic in the future."
     title="Click if you want me to write more about this topic in the future.">
     <svg 
         class="vote-link" 
         viewBox="0 0 22 27" 
         style="height: 1em; width: 0.815em">
         <circle r="5" cx="11" cy="5"/><rect ry="1.5" x="3" y="9" height="18" width="16" style="stroke:#fff;stroke-width:1.5"/><ellipse rx="3" ry="4" cx="3" cy="18.5" style="stroke:#fff;stroke-width:2"/><ellipse rx="3" ry="4" cx="19" cy="18.5" style="stroke:#fff;stroke-width:2"/>
-    </svg>
-</a>
+    </svg></a> 
 {%- endmacro %}
-


### PR DESCRIPTION
This PR switches the tooltips from the Bootstrap version to the CSS of [Cooltipz](https://cooltipz.jackdomleo.dev/).

The Cooltipz library is not used directly, but rather the relevant CSS styles were copied.