### PR TITLE
Fix the cookie signature check

### DIFF
--- a/api/iwanttoreadmore/common.py
+++ b/api/iwanttoreadmore/common.py
@@ -99,5 +99,6 @@ def check_cookie_signature(cookie):
         return False
 
     cookie_without_signature, signature = cookie.split("&signature=")
+    signature = signature.split(";")[0]
     cookie_with_secret = cookie_without_signature + get_cookie_secret()
     return bcrypt.checkpw(cookie_with_secret.encode(), signature.encode())

--- a/api/tests/test_common.py
+++ b/api/tests/test_common.py
@@ -121,6 +121,11 @@ class CommonTestCase(unittest.TestCase):
                 "user=haltakov&signature=$2b$12$FTU0sMh7DANHArQW1CBGiuKdkfpeViomU/Smp2TFBwv0wmBhMEizC"
             )
         )
+        self.assertTrue(
+            check_cookie_signature(
+                "user=haltakov&signature=$2b$12$FTU0sMh7DANHArQW1CBGiuKdkfpeViomU/Smp2TFBwv0wmBhMEizC; loggedin="
+            )
+        )
         self.assertFalse(
             check_cookie_signature(
                 "user=otheruser&signature=$2b$12$FTU0sMh7DANHArQW1CBGiuKdkfpeViomU/Smp2TFBwv0wmBhMEizC"


### PR DESCRIPTION
There was a problem with the signature check if there was a second cookie after the first one (as Safari usually does it).