### PR TITLE
Fix double voting problem

### DIFF
--- a/api/iwanttoreadmore/common.py
+++ b/api/iwanttoreadmore/common.py
@@ -1,5 +1,6 @@
 import re
 import time
+import hashlib
 import urllib.parse
 import boto3
 import bcrypt
@@ -157,3 +158,35 @@ def get_logged_in_user(event):
         return None
 
     return check_cookie_signature(event["headers"]["Cookie"])
+
+
+def hash_string(data):
+    """
+    Create a generic hash for the given string
+    :param data: string to be hashed
+    :return: hash
+    """
+    return hashlib.sha1(data.encode()).hexdigest()
+
+
+def get_ip_address(event):
+    """
+    Retrieves the client IP address from an event
+    :param event: event
+    :return: client IP address
+    """
+    if "headers" in event:
+        if "Client-Ip" in event["headers"]:
+            return event["headers"]["Client-Ip"]
+        if "X-Forwarded-For" in event["headers"]:
+            return event["headers"]["X-Forwarded-For"].split(",")[0]
+
+    if (
+        "requestContext" in event
+        and "identity" in event["requestContext"]
+        and "sourceIp" in event["requestContext"]["identity"]
+    ):
+        return event["requestContext"]["identity"]["sourceIp"]
+
+    return ""
+

--- a/api/iwanttoreadmore/handlers/handlers_vote.py
+++ b/api/iwanttoreadmore/handlers/handlers_vote.py
@@ -2,7 +2,7 @@ import re
 import json
 import logging
 from urllib.parse import quote_plus
-from iwanttoreadmore.common import get_logged_in_user
+from iwanttoreadmore.common import get_logged_in_user, get_ip_address
 from iwanttoreadmore.handlers.handler_helpers import create_response
 from iwanttoreadmore.models.vote import Vote, get_topic_key
 from iwanttoreadmore.models.vote_history import VoteHistory
@@ -33,7 +33,8 @@ def do_vote(event, _):
         return
 
     # Check if this IP address already voted for this topic
-    ip_address = event["requestContext"]["identity"]["sourceIp"]
+    log.debug(f"Event: {event}")
+    ip_address = get_ip_address(event)
 
     vote_history = VoteHistory()
     if vote_history.check_ip_voted(user, get_topic_key(project, topic), ip_address):

--- a/api/iwanttoreadmore/models/vote_history.py
+++ b/api/iwanttoreadmore/models/vote_history.py
@@ -2,7 +2,7 @@ import os
 from decimal import Decimal
 import boto3
 from boto3.dynamodb.conditions import Key
-from iwanttoreadmore.common import get_current_timestamp
+from iwanttoreadmore.common import get_current_timestamp, hash_string
 
 
 class VoteHistory:
@@ -15,7 +15,7 @@ class VoteHistory:
         Initialize a new VoteHistory object, containing a reference to the vote history DynamoDB table
         """
         self.votes_history_table = boto3.resource("dynamodb").Table(
-            os.environ["VOTE_HISTORY_TABLE"]
+            os.environ["VOTES_HISTORY_TABLE"]
         )
 
     def add_vote_history(self, user, topic_key, ip_address):
@@ -31,7 +31,7 @@ class VoteHistory:
                     "User": user,
                     "TopicKey": topic_key,
                     "VoteTimestamp": get_current_timestamp(),
-                    "IPHash": hash(user + topic_key + ip_address),
+                    "IPHash": hash_string(user + topic_key + ip_address),
                 }
             )
 
@@ -60,7 +60,7 @@ class VoteHistory:
         :param ip_address: IP address to check
         :return: False if the IP address hasn't vote for this topic yet, True otherwise
         """
-        ip_hash = hash(user + topic_key + ip_address)
+        ip_hash = hash_string(user + topic_key + ip_address)
 
         vote = self.votes_history_table.query(
             ProjectionExpression="IPHash",

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -13,7 +13,7 @@ provider:
     environment:
         VOTES_TABLE: ${self:service}-votes-${opt:stage, self:provider.stage}
         USERS_TABLE: ${self:service}-users-${opt:stage, self:provider.stage}
-        VOTE_HISTORY_TABLE: ${self:service}-vote-history-${opt:stage, self:provider.stage}
+        VOTES_HISTORY_TABLE: ${self:service}-votes-history-${opt:stage, self:provider.stage}
     iamRoleStatements:
         - Effect: Allow
           Action:
@@ -41,7 +41,7 @@ provider:
               - dynamodb:PutItem
               - dynamodb:UpdateItem
               - dynamodb:DeleteItem
-          Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.VOTE_HISTORY_TABLE}"
+          Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.VOTES_HISTORY_TABLE}"
         - Effect: Allow
           Action:
               - ssm:GetParameter
@@ -178,13 +178,13 @@ resources:
                     ReadCapacityUnits: 1
                     WriteCapacityUnits: 1
                 TableName: ${self:provider.environment.USERS_TABLE}
-        IWTRMVoteHistoryDynamoDbTable:
+        IWTRMVotesHistoryDynamoDbTable:
             Type: "AWS::DynamoDB::Table"
             DeletionPolicy: Retain
             Properties:
                 AttributeDefinitions:
                     - AttributeName: IPHash
-                      AttributeType: N
+                      AttributeType: S
                     - AttributeName: User
                       AttributeType: S
                     - AttributeName: TopicKey
@@ -195,7 +195,7 @@ resources:
                 ProvisionedThroughput:
                     ReadCapacityUnits: 2
                     WriteCapacityUnits: 2
-                TableName: ${self:provider.environment.VOTE_HISTORY_TABLE}
+                TableName: ${self:provider.environment.VOTES_HISTORY_TABLE}
                 GlobalSecondaryIndexes:
                     - IndexName: UserTopicKey
                       KeySchema:

--- a/api/tests/data/data_test_vote_history.py
+++ b/api/tests/data/data_test_vote_history.py
@@ -1,5 +1,6 @@
 import boto3
 from decimal import Decimal
+from iwanttoreadmore.common import hash_string
 
 
 def create_vote_history_table(table_name):
@@ -12,7 +13,7 @@ def create_vote_history_table(table_name):
     return dynamodb.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "IPHash", "KeyType": "HASH"},],
-        AttributeDefinitions=[{"AttributeName": "User", "AttributeType": "N"},],
+        AttributeDefinitions=[{"AttributeName": "User", "AttributeType": "S"},],
         GlobalSecondaryIndexes=[
             {
                 "IndexName": "UserTopicKey",
@@ -46,7 +47,7 @@ def create_test_vote_history_data(votes_table):
             "ProjectName": "project_a",
             "Topic": "topic_aaa",
             "VoteTimestamp": Decimal(1111),
-            "IPHash": hash("user_1" + "project_a/topic_aaa" + "192.168.0.1"),
+            "IPHash": hash_string("user_1" + "project_a/topic_aaa" + "192.168.0.1"),
         }
     )
     votes_table.put_item(
@@ -56,7 +57,7 @@ def create_test_vote_history_data(votes_table):
             "ProjectName": "project_a",
             "Topic": "topic_aaa",
             "VoteTimestamp": Decimal(2222),
-            "IPHash": hash("user_1" + "project_a/topic_aaa" + "192.168.0.2"),
+            "IPHash": hash_string("user_1" + "project_a/topic_aaa" + "192.168.0.2"),
         }
     )
     votes_table.put_item(
@@ -66,7 +67,7 @@ def create_test_vote_history_data(votes_table):
             "ProjectName": "project_a",
             "Topic": "topic_bbb",
             "VoteTimestamp": Decimal(3333),
-            "IPHash": hash("user_1" + "project_a/topic_bbb" + "192.168.0.2"),
+            "IPHash": hash_string("user_1" + "project_a/topic_bbb" + "192.168.0.2"),
         }
     )
 

--- a/api/tests/handlers/test_handlers_vote.py
+++ b/api/tests/handlers/test_handlers_vote.py
@@ -20,7 +20,9 @@ from tests.helpers import remove_table, create_cookie_parameter, delete_cookie_p
 
 
 def add_ip_address(event):
-    event["requestContext"] = dict(identity=dict(sourceIp="192.168.0.1"))
+    if "headers" not in event:
+        event["headers"] = dict()
+    event["headers"]["Client-Ip"] = "192.168.0.1"
     return event
 
 

--- a/api/tests/models/test_vote_history.py
+++ b/api/tests/models/test_vote_history.py
@@ -17,15 +17,15 @@ class VoteHistoryTestCase(unittest.TestCase):
         """
         Create a vote history table and populate it with example data
         """
-        os.environ["VOTE_HISTORY_TABLE"] = "iwanttoreadmore-vote-history-test"
+        os.environ["VOTES_HISTORY_TABLE"] = "iwanttoreadmore-votes-history-test"
 
         self.vote_history_table = create_vote_history_table(
-            os.environ["VOTE_HISTORY_TABLE"]
+            os.environ["VOTES_HISTORY_TABLE"]
         )
         create_test_vote_history_data(self.vote_history_table)
 
     def tearDown(self):
-        remove_table(os.environ["VOTE_HISTORY_TABLE"])
+        remove_table(os.environ["VOTES_HISTORY_TABLE"])
 
     def test_get_vote_history(self):
         vote_history = VoteHistory()

--- a/api/tests/test_common.py
+++ b/api/tests/test_common.py
@@ -16,6 +16,8 @@ from iwanttoreadmore.common import (
     get_cookie_secret,
     sign_cookie,
     check_cookie_signature,
+    hash_string,
+    get_ip_address,
 )
 
 
@@ -162,6 +164,42 @@ class CommonTestCase(unittest.TestCase):
             ),
         )
         self.assertEqual(None, check_cookie_signature("user=haltakov"))
+
+    def test_hash_string(self):
+        self.assertEqual(
+            "67e97cce0420c8def20b568c93e97f86c186b35c", hash_string("test_string_1")
+        )
+        self.assertNotEqual(hash_string("test_string_1"), hash_string("test_string_2"))
+        self.assertNotEqual(hash_string("a" * 10000), hash_string("a" * 9999 + "b"))
+
+    def get_ip_address(self):
+        self.assertEqual(
+            "192.168.0.1",
+            {
+                "headers": {
+                    "Client-Ip": "192.168.0.1",
+                    "X-Forwarded-For": "192.168.0.2, 10.10.10.10",
+                },
+                "requestContext": {"identity": {"sourceIp": "192.168.0.3",},},
+            },
+        )
+
+        self.assertEqual(
+            "192.168.0.2",
+            {
+                "headers": {"X-Forwarded-For": "192.168.0.2, 10.10.10.10",},
+                "requestContext": {"identity": {"sourceIp": "192.168.0.3",},},
+            },
+        )
+
+        self.assertEqual(
+            "192.168.0.3",
+            {"requestContext": {"identity": {"sourceIp": "192.168.0.3",},},},
+        )
+
+        self.assertEqual(
+            "", {},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a problem with double voting in some situations.

- Change the hash function for the vote history
- Change the way the IP address is retrieved from the event

Resolves: #59 