### PR TITLE
Show the actual username in the docs

### DIFF
--- a/website/content/pages/getting-started.md
+++ b/website/content/pages/getting-started.md
@@ -32,15 +32,15 @@ The minimal setup is just to include direct links to the vote API. When the user
 
 You can easily use way of integration on any blogging platform, like for example Hashnode (see [example](https://haltakov.hashnode.dev/i-want-to-read-more-demo)), Dev.to (see [example](https://dev.to/haltakov/i-want-to-read-more-demo-b1b)) or Wordpress (see example), because it doesn't require you to include any JavaScript or CSS. However, in this way a new page will open up instead of showing a toast.
 
-<pre><code class="language-text">https://iwanttoreadmore.com/vote/&lt;username&gt;/&lt;project&gt;/&lt;topic&gt;/</code></pre>
+<pre><code class="language-text">https://iwanttoreadmore.com/vote/<span class="username">&lt;username&gt;</span>/&lt;project&gt;/&lt;topic&gt;/</code></pre>
 
 Here is how it looks like if you are using Markdown:
 
-<pre><code class="language-markdown">[Vote](https://iwanttoreadmore.com/vote/&lt;username&gt;/&lt;project&gt;/&lt;topic&gt;/)</code></pre>
+<pre><code class="language-markdown">[Vote](https://iwanttoreadmore.com/vote/<span class="username">&lt;username&gt;</span>/&lt;project&gt;/&lt;topic&gt;/)</code></pre>
 
 On many platforms, you can also use HTML directly:
 
-<pre><code class="language-html">&lt;a href="https://iwanttoreadmore.com/vote/&lt;username&gt;/&lt;project&gt;/&lt;topic&gt;/" target="_blank" rel="noopener"&gt;Vote&lt;/a&gt;</code></pre>
+<pre><code class="language-html">&lt;a href="https://iwanttoreadmore.com/vote/<span class="username">&lt;username&gt;</span>/&lt;project&gt;/&lt;topic&gt;/" target="_blank" rel="noopener"&gt;Vote&lt;/a&gt;</code></pre>
 
 <a name="voted-message-customization"></a>
 
@@ -63,7 +63,7 @@ If you are able to include JavaScript and CSS files in your blog, you will be ab
 </code></pre>
 
 3.  To add a vote link to your text add a regular `<a>` tag with a `data-vote` attribute:
-<pre><code class="language-html">&lt;a href="#" data-vote="&lt;username&gt;/&lt;project&gt;/&lt;topic&gt;"&gt;&lt;/a&gt;
+<pre><code class="language-html">&lt;a href="#" data-vote="<span class="username">&lt;username&gt;</span>/&lt;project&gt;/&lt;topic&gt;"&gt;&lt;/a&gt;
 </code></pre>
 
 <a name="configuration-options"></a>
@@ -92,3 +92,11 @@ If you don't like the icon, the messages or the design of the toast, you can eas
 ## Need more help?
 
 If you need any further help, you can contact us directy at the e-mail you will find at the top of the [Settings](https://iwanttoreadmore.com/settings) page.
+
+<script>
+    // Replace the <username> placeholders with the actual username
+    if (document.cookie.includes("loggedinuser")) {
+        const username = document.cookie.split("=").pop();
+        document.querySelectorAll(".username").forEach((x) => x.innerHTML = username )
+    }
+</script>


### PR DESCRIPTION
This PR enables the actual username of the logged in user to be shown in the documentation instead of a placeholder.

Solves: #81 